### PR TITLE
add example script that opens widget

### DIFF
--- a/examples/show_btrack_widget.py
+++ b/examples/show_btrack_widget.py
@@ -7,8 +7,8 @@ This example:
 - loads the arboretum plugin
 - opens the napari viewer
 """
-from btrack import datasets
 import napari
+from btrack import datasets
 
 viewer = napari.Viewer()
 
@@ -22,11 +22,11 @@ btrack_widget.config_file_path.value = cell_config
 
 
 segmentation = datasets.example_segmentation()
-viewer._add_layer_from_data(segmentation)
+viewer.add_image(segmentation)
 # napari takes the first image layer as default anyway here, but better to be explicit
-btrack_widget.segmentation.value = viewer.layers['segmentation']
+btrack_widget.segmentation.value = viewer.layers["segmentation"]
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # The napari event loop needs to be run under here to allow the window
     # to be spawned from a Python script
     napari.run()

--- a/examples/show_btrack_widget.py
+++ b/examples/show_btrack_widget.py
@@ -1,0 +1,32 @@
+"""
+Load and show sample data
+=========================
+This example:
+- loads some sample data
+- adds the data to a napari viewer
+- loads the arboretum plugin
+- opens the napari viewer
+"""
+from btrack import datasets
+import napari
+
+viewer = napari.Viewer()
+
+_, btrack_widget = viewer.window.add_plugin_dock_widget(
+    plugin_name="napari-btrack", widget_name="Track"
+)
+
+# populate with example config and data
+cell_config = datasets.cell_config()
+btrack_widget.config_file_path.value = cell_config
+
+
+segmentation = datasets.example_segmentation()
+viewer._add_layer_from_data(segmentation)
+# napari takes the first image layer as default anyway here, but better to be explicit
+btrack_widget.segmentation.value = viewer.layers['segmentation']
+
+if __name__ == '__main__':
+    # The napari event loop needs to be run under here to allow the window
+    # to be spawned from a Python script
+    napari.run()

--- a/examples/show_btrack_widget.py
+++ b/examples/show_btrack_widget.py
@@ -1,10 +1,10 @@
 """
-Load and show sample data
+Show the btrack widget with example data
 =========================
 This example:
-- loads some sample data
-- adds the data to a napari viewer
-- loads the arboretum plugin
+- loads a sample segmentation and cell config
+- adds the segmentation to a napari viewer
+- loads the btrack plugin
 - opens the napari viewer
 """
 import napari


### PR DESCRIPTION
This PR
- adds a script that launches the `napari-btrack: Track` widget
- populates it with the example segmentation and default cell config file.

Implementation is analogous to examples we have written for other repos (e.g. [cellfinder-napari](https://github.com/brainglobe/cellfinder-napari/blob/main/examples/show_detection_sample.py) and [arboretum](https://github.com/lowe-lab-ucl/arboretum/blob/master/examples/show_sample_data.py)).
Useful for debugging, demo-ing and manual testing.
Closes quantumjot/btrack#259 .