### PR TITLE
isort configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
       rev: 5.10.1
       hooks:
           - id: isort
-            args: ["--profile", "black"]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.1.0
       hooks:

--- a/napari_btrack/_tests/test_dock_widget.py
+++ b/napari_btrack/_tests/test_dock_widget.py
@@ -2,14 +2,16 @@ import json
 from typing import Dict, Tuple
 from unittest.mock import patch
 
-import napari
 import numpy as np
 import numpy.typing as npt
 import pytest
+from magicgui.widgets import Container
+
+import napari
+
 from btrack import datasets
 from btrack.config import load_config
 from btrack.datasets import cell_config, particle_config
-from magicgui.widgets import Container
 
 from ..track import _update_widgets_from_config, _widgets_to_tracker_config, track
 

--- a/napari_btrack/track.py
+++ b/napari_btrack/track.py
@@ -1,10 +1,17 @@
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple, Union
+from dataclasses import field, dataclass
 
-import btrack
-import napari
 import numpy as np
 import numpy.typing as npt
+from magicgui.application import use_app
+from magicgui.types import FileDialogMode
+from magicgui.widgets import Container, PushButton, Widget, create_widget
+from pydantic import BaseModel
+from PyQt5.QtWidgets import QScrollArea
+
+import napari
+
+import btrack
 from btrack import datasets
 from btrack.config import (
     HypothesisModel,
@@ -14,11 +21,6 @@ from btrack.config import (
     save_config,
 )
 from btrack.utils import segmentation_to_objects
-from magicgui.application import use_app
-from magicgui.types import FileDialogMode
-from magicgui.widgets import Container, PushButton, Widget, create_widget
-from pydantic import BaseModel
-from PyQt5.QtWidgets import QScrollArea
 
 default_cell_config = load_config(datasets.cell_config())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 target-version = ['py38', 'py39', 'py310']
 skip-string-normalization = false
-line-length = 79
+line-length = 88
 exclude = '''
 (
   /(
@@ -21,9 +21,6 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
-multi_line_output = 3 # Vertical Hanging Indent
-line_length = 79
-include_trailing_comma = "True"
 length_sort = "False"
 length_sort_sections = "stdlib"
 known_first_party = "btrack"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[tool.black]
+target-version = ['py38', 'py39', 'py310']
+skip-string-normalization = false
+line-length = 79
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | build
+    | dist
+    | examples
+  )/
+)
+'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3 # Vertical Hanging Indent
+line_length = 79
+include_trailing_comma = "True"
+length_sort = "False"
+length_sort_sections = "stdlib"
+known_first_party = "btrack"
+known_napari = "napari"
+sections = ["STDLIB", "THIRDPARTY", "NAPARI", "FIRSTPARTY", "LOCALFOLDER"]
+skip_gitignore = "True"


### PR DESCRIPTION
This is #18 with only the isort configuration.

The import sorting has been setup with the following block ordering, so that, for example:

``` python
# stdlib
import os

# thirdparty
import magicgui
import numpy

# napari
import napari 

import btrack

from .track import superfunction
```

isort hasn't been run as it may do a lot of conflicts on the #26.