### PR TITLE
Add `napari` and fix `magicgui` bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,11 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
+    btrack>=0.4.1
+    magicgui>=0.5.0
+    napari>=0.4.0
     napari-plugin-engine>=0.1.4
     numpy
-    btrack>=0.4.1
 
 [options.entry_points]
 napari.manifest =


### PR DESCRIPTION
Fixes https://github.com/lowe-lab-ucl/napari-btrack/issues/24

Also enforcing higher `magicgui` version due to fixing bug in quantumjot/btrack#268 