### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/napari_btrack/_tests/test_dock_widget.py
+++ b/napari_btrack/_tests/test_dock_widget.py
@@ -24,9 +24,14 @@ NEW_WIDGET_LAYERS = 2
 
 def test_add_widget(make_napari_viewer):
     """Checks that the track widget can be added inside a dock widget."""
+
     viewer = make_napari_viewer()
     num_dw = len(list(viewer.window._dock_widgets))
-    viewer.window.add_function_widget(function=track)
+    viewer.window.add_plugin_dock_widget(
+        plugin_name="napari-btrack",
+        widget_name="Track",
+    )
+
     assert len(list(viewer.window._dock_widgets)) == num_dw + 1  # noqa: S101
 
 

--- a/napari_btrack/track.py
+++ b/napari_btrack/track.py
@@ -354,7 +354,7 @@ def _update_widgets_from_config(container: Container, config: TrackerConfig) -> 
                 if parameter in Matrices().names:
                     sigma = Matrices.get_sigma(parameter, value)
                     getattr(container, f"{parameter}_sigma").value = sigma
-                if parameter == "hypotheses":
+                elif parameter == "hypotheses":
                     for hypothesis in ALL_HYPOTHESES:
                         getattr(container, hypothesis).value = hypothesis in value
                 else:

--- a/napari_btrack/track.py
+++ b/napari_btrack/track.py
@@ -47,6 +47,16 @@ class Matrices:
     """
 
     names: list[str] = field(default_factory=lambda: ["A", "H", "P", "G", "R", "Q"])
+    widget_labels: list[str] = field(
+        default_factory=lambda: [
+            "A_sigma",
+            "H_sigma",
+            "P_sigma",
+            "G_sigma",
+            "R_sigma",
+            "Q_sigma",
+        ]
+    )
     default_sigmas: list[float] = field(
         default_factory=lambda: [1.0, 1.0, 150.0, 15.0, 5.0]
     )
@@ -284,14 +294,15 @@ def _widgets_to_tracker_config(container: Container) -> TrackerConfig:
     for widget in container:
         # setup motion model
         # matrices need special treatment
-        if widget.name in Matrices().names:
-            sigma = getattr(container, f"{widget.name}_sigma").value
+        if widget.name in Matrices().widget_labels:
+            sigma = getattr(container, widget.name).value
+            matrix_name = widget.name.rstrip("_sigma")
             matrix = Matrices.get_scaled_matrix(
-                widget.name,
+                matrix_name,
                 sigma=sigma,
                 use_cell_config=(container.mode.value == "cell"),
             )
-            motion_model_dict[widget.name] = matrix
+            motion_model_dict[matrix_name] = matrix
         elif widget.name in motion_model_keys:
             motion_model_dict[widget.name] = widget.value
         # setup hypothesis model

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,15 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39}-{linux,macos,windows}
+envlist = py{38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Fixes quantumjot/btrack#276 

Tests were failing for various reasons:

- `add_plugin_dock_widget` should be used instead of `add_function_widget` to add the plugin to napari for testing

- when updating the config with values from the widgets, the widget name is used to set the key for the corresponding value in the config. However, for matrices, the widget names are e.g. `A_sigma` but the matrix name in the config is e.g. `A`. I've added a `Matrices.widget_name` attribute so we can map between widget names and matrix names

- in the same function (`_update_widgets_from_config`), the check `if parameter == "hypotheses` should use an `elif` instead. Otherwise matrix widgets will be added to the config twice (the second time using the actual widget name)

I've also removed support and testing of Python 3.7. `BayesianTracker` is [also only tested](https://github.com/quantumjot/BayesianTracker/blob/main/.github/workflows/test.yml#L33) on 3.8 - 3.10 