### PR TITLE
Make the btrack widget scrollable

### DIFF
--- a/napari_btrack/track.py
+++ b/napari_btrack/track.py
@@ -407,7 +407,7 @@ def track() -> Container:
     _create_pydantic_default_widgets(widgets, default_cell_config)
     _create_button_widgets(widgets)
 
-    btrack_widget = Container(widgets=widgets)
+    btrack_widget = Container(widgets=widgets, scrollable=True)
     btrack_widget.viewer = napari.current_viewer()
 
     @btrack_widget.reset_button.changed.connect


### PR DESCRIPTION
Fixes quantumjot/btrack#277 

There's now a scrollbar so we can access all the widgets
<img width="1440" alt="scrollbar" src="https://user-images.githubusercontent.com/29753790/222483511-aa2a8b7c-a65c-4505-a769-477bf0ca564b.png">

Needed to set `scrollable=True` when creating the container